### PR TITLE
Overlap only feature and interface with pymatgen

### DIFF
--- a/src/HPRO/deephio.py
+++ b/src/HPRO/deephio.py
@@ -63,6 +63,7 @@ def save_orbital_types_deeph(structure, ion_dir, savedir):
             f.write(' '.join(map(str, l_values)) + '\n')
 
 def save_overlap_deeph(structure, ecut, basis_path_root, savedir, filename='overlaps.h5', energy_unit=False):
+    os.makedirs(savedir, exist_ok=True)
     basis = LCAOData(structure, basis_path_root=basis_path_root, aocode='siesta')
 
     basis.calc_phiQ(ecut * 1.1)
@@ -87,7 +88,7 @@ def save_overlap_deeph(structure, ecut, basis_path_root, savedir, filename='over
             orbpairs1[(spc1, spc2)] = orbpairs_thisij1
 
     olp_basis = calc_overlap(basis, orbpairs1, Ecut=ecut)
-    save_mat_deeph(savedir,olp_basis,filename=filename,energy_unit=False)
+    save_mat_deeph(savedir,olp_basis,filename=filename,energy_unit=energy_unit)
 
 
 def get_Us_openmx2wiki(ls_spc):

--- a/src/HPRO/deephio.py
+++ b/src/HPRO/deephio.py
@@ -88,7 +88,7 @@ def save_overlap_deeph(structure, ecut, basis_path_root, savedir, filename='over
 
     olp_basis = calc_overlap(basis, orbpairs1, Ecut=ecut)
     error_hermiticity = olp_basis.hermitianize()
-    print(f'Errore di non-Hermiticità per la matrice di sovrapposizione: {error_hermiticity}')
+    print(f'Overlap non-Hermiticity error: {error_hermiticity}')
 
     #save structure, overlap matrix and orbital_types
     save_structure_deeph(structure=structure,savedir=savedir)

--- a/src/HPRO/deephio.py
+++ b/src/HPRO/deephio.py
@@ -88,8 +88,10 @@ def save_overlap_deeph(structure, ecut, basis_path_root, savedir, filename='over
 
     olp_basis = calc_overlap(basis, orbpairs1, Ecut=ecut)
     error_hermiticity = olp_basis.hermitianize()
-    print(f'Errore di non-Hermiticità per la matrice di sovrapposizione: {error_hermiticity} [10]')
+    print(f'Errore di non-Hermiticità per la matrice di sovrapposizione: {error_hermiticity}')
 
+    #save structure, overlap matrix and orbital_types
+    save_structure_deeph(structure=structure,savedir=savedir)
     save_mat_deeph(savedir,olp_basis,filename=filename,energy_unit=energy_unit)
 
 

--- a/src/HPRO/deephio.py
+++ b/src/HPRO/deephio.py
@@ -9,7 +9,8 @@ from .structure import Structure
 from .matlcao import MatLCAO
 from .lcaodata import LCAOData # this might be unsafe?
 from .utils import slice_same
-
+from .orbutils import OrbPair 
+from .twocenter import calc_overlap
 '''
 This module implemements several functions for reading and writing files in deeph format
 '''
@@ -59,6 +60,34 @@ def save_orbital_types_deeph(structure, ion_dir, savedir):
     with open(file_path, 'w') as f:
         for atom_nbr in atom_numbers_in_structure:
             l_values = orbital_types_per_species[atom_nbr]
+            f.write(' '.join(map(str, l_values)) + '\n')
+
+def save_overlap_deeph(structure, ecut, basis_path_root, savedir, filename='overlaps.h5', energy_unit=False):
+    basis = LCAOData(structure, basis_path_root=basis_path_root, aocode='siesta')
+
+    basis.calc_phiQ(ecut * 1.1)
+    orbpairs1 = {}
+    stru = structure
+
+    for ispc1 in range(stru.nspc):
+        for jspc2 in range(stru.nspc):
+            spc1 = stru.atomic_species[ispc1]
+            spc2 = stru.atomic_species[jspc2]
+
+            orbpairs_thisij1 = []
+            for jorb in range(basis.norb_spc[spc2]):
+
+                r2 = basis.phirgrids_spc[spc2][jorb].rcut
+                for iorb in range(basis.norb_spc[spc1]):
+                    r1 = basis.phirgrids_spc[spc1][iorb].rcut
+                    thispair = OrbPair(basis.phiQlist_spc[spc1][iorb],
+                                    basis.phiQlist_spc[spc2][jorb], r1 + r2, 1)
+                    orbpairs_thisij1.append(thispair)
+
+            orbpairs1[(spc1, spc2)] = orbpairs_thisij1
+
+    olp_basis = calc_overlap(basis, orbpairs1, Ecut=ecut)
+    save_mat_deeph(savedir,olp_basis,filename=filename,energy_unit=False)
 
 
 def get_Us_openmx2wiki(ls_spc):

--- a/src/HPRO/deephio.py
+++ b/src/HPRO/deephio.py
@@ -65,15 +65,14 @@ def save_orbital_types_deeph(structure, ion_dir, savedir):
 def save_overlap_deeph(structure, ecut, basis_path_root, savedir, filename='overlaps.h5', energy_unit=False):
     os.makedirs(savedir, exist_ok=True)
     basis = LCAOData(structure, basis_path_root=basis_path_root, aocode='siesta')
-
+    basis.check_rstart()
     basis.calc_phiQ(ecut * 1.1)
-    orbpairs1 = {}
-    stru = structure
 
-    for ispc1 in range(stru.nspc):
-        for jspc2 in range(stru.nspc):
-            spc1 = stru.atomic_species[ispc1]
-            spc2 = stru.atomic_species[jspc2]
+    orbpairs1 = {}
+    for ispc1 in range(structure.nspc):
+        for jspc2 in range(structure.nspc):
+            spc1 = structure.atomic_species[ispc1]
+            spc2 = structure.atomic_species[jspc2]
 
             orbpairs_thisij1 = []
             for jorb in range(basis.norb_spc[spc2]):
@@ -88,6 +87,9 @@ def save_overlap_deeph(structure, ecut, basis_path_root, savedir, filename='over
             orbpairs1[(spc1, spc2)] = orbpairs_thisij1
 
     olp_basis = calc_overlap(basis, orbpairs1, Ecut=ecut)
+    error_hermiticity = olp_basis.hermitianize()
+    print(f'Errore di non-Hermiticità per la matrice di sovrapposizione: {error_hermiticity} [10]')
+
     save_mat_deeph(savedir,olp_basis,filename=filename,energy_unit=energy_unit)
 
 

--- a/src/HPRO/deephio.py
+++ b/src/HPRO/deephio.py
@@ -62,7 +62,7 @@ def save_orbital_types_deeph(structure, ion_dir, savedir):
             l_values = orbital_types_per_species[atom_nbr]
             f.write(' '.join(map(str, l_values)) + '\n')
 
-def save_overlap_deeph(structure, ecut, basis_path_root, savedir, filename='overlaps.h5', energy_unit=False):
+def save_overlap_deeph(structure, ecut, basis_path_root, savedir, filename='overlaps.h5', energy_unit=False, buffer = 0.0):
     os.makedirs(savedir, exist_ok=True)
     basis = LCAOData(structure, basis_path_root=basis_path_root, aocode='siesta')
     basis.check_rstart()
@@ -81,7 +81,7 @@ def save_overlap_deeph(structure, ecut, basis_path_root, savedir, filename='over
                 for iorb in range(basis.norb_spc[spc1]):
                     r1 = basis.phirgrids_spc[spc1][iorb].rcut
                     thispair = OrbPair(basis.phiQlist_spc[spc1][iorb],
-                                    basis.phiQlist_spc[spc2][jorb], r1 + r2, 1)
+                                    basis.phiQlist_spc[spc2][jorb], r1 + r2 + buffer, 1)
                     orbpairs_thisij1.append(thispair)
 
             orbpairs1[(spc1, spc2)] = orbpairs_thisij1

--- a/src/HPRO/deephio.py
+++ b/src/HPRO/deephio.py
@@ -40,6 +40,27 @@ Us_openmx2wiki = {
     3: np.eye(7)[[6, 4, 2, 0, 1, 3, 5]]
 }
 
+def save_orbital_types_deeph(structure, ion_dir, savedir):
+    """
+    Save the orbital_types.dat file in deeph format.
+
+    """
+    os.makedirs(savedir, exist_ok=True)
+    lcaodata = LCAOData(
+        structure=structure,
+        basis_path_root=ion_dir,
+        aocode='siesta'
+    )
+
+    atom_numbers_in_structure = lcaodata.structure.atomic_numbers
+    orbital_types_per_species = lcaodata.ls_spc
+
+    file_path = os.path.join(savedir, 'orbital_types.dat')
+    with open(file_path, 'w') as f:
+        for atom_nbr in atom_numbers_in_structure:
+            l_values = orbital_types_per_species[atom_nbr]
+
+
 def get_Us_openmx2wiki(ls_spc):
     '''
     DeepH follows the OpenMX definition of spherical harmonics, but this software follows Wikipedia's convention.

--- a/src/HPRO/structure.py
+++ b/src/HPRO/structure.py
@@ -111,6 +111,14 @@ class Structure:
     
     @classmethod
     def from_pymatgen(cls, pmg_structure):
+        """
+        Load a structure in deeph format from a pymatgen structure
+
+        Parameters:
+        pmg_structure: 
+        The structure object, can be either a pmg structure or a file in a 
+        format readable by pymatgen
+        """
         if isinstance(pmg_structure, str):
             pmg_structure = PmgStructure.from_file(pmg_structure)
         rprim = pmg_structure.lattice.matrix / bohr2ang
@@ -174,8 +182,8 @@ def save_pymatgen_structure(structure, filename):
     Save a pymatgen structure to a file in the desired format.
     
     Parameters:
-    structure (pymatgen.core.Structure): The structure to save.
-    filename (str): The name of the file to save the structure to.
+    structure: The structure to save.
+    filename: The name of the file to save the structure to.
     """
     lattice = structure.rprim * bohr2ang
     species = atom_number2name(structure.atomic_numbers)

--- a/src/HPRO/structure.py
+++ b/src/HPRO/structure.py
@@ -2,6 +2,7 @@ import json
 import os
 import numpy as np
 import xml.etree.ElementTree as ET
+from pymatgen.core import Structure as PmgStructure
 
 from .constants import bohr2ang, hartree2ev
 from .utils import atom_name2number, atom_number2name
@@ -107,6 +108,17 @@ class Structure:
             elements = elements[None]
             atom_pos_cart = atom_pos_cart[None, :]
         return cls(rprim, elements, atom_pos_cart, efermi, atomic_positions_is_cart=True)
+    
+    @classmethod
+    def from_pymatgen(cls, pmg_structure):
+        if isinstance(pmg_structure, str):
+            pmg_structure = PmgStructure.from_file(pmg_structure)
+        rprim = pmg_structure.lattice.matrix / bohr2ang
+        atom_names = [atom.symbol for atom in pmg_structure.species]
+        atomic_numbers = np.array(atom_name2number(atom_names))
+        atomic_positions_red = pmg_structure.frac_coords
+        efermi = 0.0
+        return cls(rprim, atomic_numbers, atomic_positions_red, efermi, atomic_positions_is_cart=False)
         
     def __eq__(self, other):
         return self.issame(other)
@@ -144,6 +156,8 @@ def load_structure(path, interface):
             raise ValueError(f'Invalid QE structure path: {path}')
     elif interface == 'bgw':
         stru = Structure.from_bgw(path)
+    elif interface == 'pymatgen':
+        stru = Structure.from_pymatgen(path)
     elif interface == 'vasp':
         with open(path) as f:
             stru = Structure.from_poscar(f)
@@ -154,3 +168,17 @@ def load_structure(path, interface):
     else:
         raise NotImplementedError(f'Unknown structure interface: {interface}')
     return stru
+
+def save_pymatgen_structure(structure, filename):
+    """
+    Save a pymatgen structure to a file in the desired format.
+    
+    Parameters:
+    structure (pymatgen.core.Structure): The structure to save.
+    filename (str): The name of the file to save the structure to.
+    """
+    lattice = structure.rprim * bohr2ang
+    species = atom_number2name(structure.atomic_numbers)
+    frac_coords = structure.atomic_positions_red
+    pmg_structure = PmgStructure(lattice=lattice, species=species, coords=frac_coords)
+    pmg_structure.to(filename)


### PR DESCRIPTION
Dear developers,

I have added to the HPRO code a function that writes the overlap matrix starting only from a structure and the ion files from SIESTA.

Additionally, I introduced an interface in the Structure class for compatibility with pymatgen structures.

I hope these additions are useful to you.

Best regards,
Enrico